### PR TITLE
Prettier, LocalStorage and JQuery removal

### DIFF
--- a/javascripts/discourse/controllers/discourse-placeholder-builder.js
+++ b/javascripts/discourse/controllers/discourse-placeholder-builder.js
@@ -12,7 +12,7 @@ export default Controller.extend(ModalFunctionality, {
       EmberObject.create({
         key: null,
         description: null,
-        values: []
+        values: [],
       })
     );
   },
@@ -43,5 +43,5 @@ export default Controller.extend(ModalFunctionality, {
     this.model.toolbarEvent.addText(`${output}][/wrap]`);
 
     this.send("closeModal");
-  }
+  },
 });

--- a/javascripts/discourse/initializers/setup.js
+++ b/javascripts/discourse/initializers/setup.js
@@ -46,14 +46,14 @@ function buildSelect(key, placeholder) {
   if (placeholder.description) {
     addSelectOption(select, {
       value: "none",
-      description: placeholder.description
+      description: placeholder.description,
     });
   }
 
-  placeholder.defaults.forEach(value =>
+  placeholder.defaults.forEach((value) =>
     addSelectOption(select, {
       value,
-      selected: placeholder.default === value
+      selected: placeholder.default === value,
     })
   );
 
@@ -64,7 +64,7 @@ export default {
   name: "discourse-placeholder-theme-component",
 
   initialize() {
-    withPluginApi("0.8.7", api => {
+    withPluginApi("0.8.7", (api) => {
       api.decorateCooked(
         ($cooked, postWidget) => {
           if (!postWidget) return;
@@ -103,7 +103,7 @@ export default {
               let replaced = false;
               let newInnnerHTML = elem.innerHTML;
 
-              mapping.forEach(m => {
+              mapping.forEach((m) => {
                 if (
                   m.pattern !==
                   `${placeholder.delimiter}${key}${placeholder.delimiter}`
@@ -136,7 +136,7 @@ export default {
 
             const keys = Object.keys(placeholders);
             const pattern = keys
-              .map(key => {
+              .map((key) => {
                 const placeholder = placeholders[key];
                 return `(${placeholder.delimiter}${key}${placeholder.delimiter})`;
               })
@@ -152,7 +152,7 @@ export default {
                 mappings[index].push({
                   pattern: match[0],
                   position: match.index,
-                  length: match[0].length
+                  length: match[0].length,
                 });
               }
             });
@@ -163,7 +163,7 @@ export default {
               processPlaceholders(placeholders, $cooked, mappings);
 
               // trigger fake event to setup initial state
-              Object.keys(placeholders).forEach(placeholderKey => {
+              Object.keys(placeholders).forEach((placeholderKey) => {
                 const placeholder = placeholders[placeholderKey];
                 const placeholderIdentifier = `${postIdentifier}${placeholderKey}`;
                 const value =
@@ -174,9 +174,9 @@ export default {
                     value,
                     dataset: {
                       key: placeholderKey,
-                      delimiter: placeholder.delimiter
-                    }
-                  }
+                      delimiter: placeholder.delimiter,
+                    },
+                  },
                 });
               });
             }
@@ -186,7 +186,7 @@ export default {
             ".d-wrap[data-wrap=placeholder]:not(.placeholdered)"
           );
 
-          placeholderNodes.forEach(elem => {
+          placeholderNodes.forEach((elem) => {
             const dataKey = elem.dataset.key;
 
             if (!dataKey) return;
@@ -201,7 +201,7 @@ export default {
               default: valueFromCookie || elem.dataset.default,
               defaults: defaultValues,
               delimiter: elem.dataset.delimiter || DELIMITER,
-              description: elem.dataset.description
+              description: elem.dataset.description,
             };
 
             const span = document.createElement("span");
@@ -225,10 +225,10 @@ export default {
           });
 
           $cooked
-            .on("input", ".discourse-placeholder-value", inputEvent =>
+            .on("input", ".discourse-placeholder-value", (inputEvent) =>
               debounce(this, processChange, inputEvent, 150)
             )
-            .on("change", ".discourse-placeholder-select", inputEvent =>
+            .on("change", ".discourse-placeholder-select", (inputEvent) =>
               debounce(this, processChange, inputEvent, 150)
             );
 
@@ -241,7 +241,7 @@ export default {
         return {
           action: "insertPlaceholder",
           icon: "file",
-          label: themePrefix("toolbar.builder")
+          label: themePrefix("toolbar.builder"),
         };
       });
 
@@ -252,12 +252,12 @@ export default {
           insertPlaceholder() {
             showModal("discourse-placeholder-builder", {
               model: {
-                toolbarEvent: this.toolbarEvent
-              }
+                toolbarEvent: this.toolbarEvent,
+              },
             });
-          }
-        }
+          },
+        },
       });
     });
-  }
+  },
 };

--- a/javascripts/discourse/initializers/setup.js
+++ b/javascripts/discourse/initializers/setup.js
@@ -128,8 +128,8 @@ export default {
     this.expireOldValues();
 
     withPluginApi("0.8.7", (api) => {
-      api.decorateCooked(
-        ($cooked, postWidget) => {
+      api.decorateCookedElement(
+        (cooked, postWidget) => {
           if (!postWidget) return;
 
           const postIdentifier = `${postWidget.widget.attrs.topicId}-${postWidget.widget.attrs.id}-`;
@@ -157,7 +157,7 @@ export default {
               newValue = `${placeholder.delimiter}${key}${placeholder.delimiter}`;
             }
 
-            $cooked.find(VALID_TAGS).each((index, elem) => {
+            cooked.querySelectorAll(VALID_TAGS).forEach((elem, index) => {
               const mapping = mappings[index];
 
               if (!mapping) return;
@@ -206,7 +206,7 @@ export default {
               .join("|");
             const regex = new RegExp(pattern, "g");
 
-            $cooked.find(VALID_TAGS).each((index, elem) => {
+            cooked.querySelectorAll(VALID_TAGS).forEach((elem, index) => {
               let match;
 
               mappings[index] = mappings[index] || [];
@@ -223,7 +223,7 @@ export default {
 
           const _fillPlaceholders = () => {
             if (Object.keys(placeholders).length > 0) {
-              processPlaceholders(placeholders, $cooked, mappings);
+              processPlaceholders(placeholders, cooked, mappings);
 
               // trigger fake event to setup initial state
               Object.keys(placeholders).forEach((placeholderKey) => {
@@ -245,7 +245,7 @@ export default {
             }
           };
 
-          const placeholderNodes = $cooked[0].querySelectorAll(
+          const placeholderNodes = cooked.querySelectorAll(
             ".d-wrap[data-wrap=placeholder]:not(.placeholdered)"
           );
 
@@ -287,13 +287,16 @@ export default {
             }
           });
 
-          $cooked
-            .on("input", ".discourse-placeholder-value", (inputEvent) =>
-              debounce(this, processChange, inputEvent, 150)
-            )
-            .on("change", ".discourse-placeholder-select", (inputEvent) =>
-              debounce(this, processChange, inputEvent, 150)
-            );
+          cooked
+            .querySelectorAll(".discourse-placeholder-value")
+            .forEach((el) => {
+              el.addEventListener("input", (inputEvent) =>
+                debounce(this, processChange, inputEvent, 150)
+              );
+              el.addEventListener("change", (inputEvent) =>
+                debounce(this, processChange, inputEvent, 150)
+              );
+            });
 
           later(_fillPlaceholders, 500);
         },


### PR DESCRIPTION
**DEV: Apply prettier, remove es6 extension**

---

**DEV: Migrate to local storage**

Setting cookies means that they're sent in the request headers for every HTTP request. This will have a (tiny) impact on performance, plus it can raise privacy concerns. Using localStorage is more appropriate for this use case.

This commit includes migration logic for any previously-saved values.

Previously the cookies were set to last for the 'session'. localStorage doesn't have an expiration mechanism, so this commit implements a 7-day expiration on the values.

---

**DEV: Remove JQuery**