### PR TITLE
FIX: fully rely on keyValueStore to prevent error

### DIFF
--- a/javascripts/discourse/initializers/setup.js
+++ b/javascripts/discourse/initializers/setup.js
@@ -1,7 +1,6 @@
 import showModal from "discourse/lib/show-modal";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { debounce, later } from "@ember/runloop";
-import cookie, { removeCookie } from "discourse/lib/cookie";
 
 const VALID_TAGS =
   "h1, h2, h3, h4, h5, h6, p, code, blockquote, .md-table, li p";


### PR DESCRIPTION
The component was generating errors for some users due to direct access to `localStorage`:

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.expireOldValues (https://d3bpeqsaub0i6y.cloudfront.net/theme-javascripts/33bf35dc19b970a42f8c1e7d57d8cc72d6205bbd.js?__ws=meta.discourse.org:157:14)
    at Object.initialize (https://d3bpeqsaub0i6y.cloudfront.net/theme-javascripts/33bf35dc19b970a42f8c1e7d57d8cc72d6205bbd.js?__ws=meta.discourse.org:193:12)
    at o.initialize (https://d11a6trkgmumsb.cloudfront.net/assets/discourse-2bd9a9aa6b5c9cbee990a03159f5bff41fe503fe74814c3b66b3770876913dd5.gz.js:68:38)
```

This commits removes old unnecessary code using cookies and uses latest API from core `removeKeys`. Old discourse instances will just not evict old keys which is a minor annoyance.