### PR TITLE
FIX: ensures placeholders works in lists

### DIFF
--- a/javascripts/discourse/initializers/setup.js
+++ b/javascripts/discourse/initializers/setup.js
@@ -3,7 +3,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import DiscoursePlaceholderBuilder from "../components/modal/discourse-placeholder-builder";
 
 const VALID_TAGS =
-  "h1, h2, h3, h4, h5, h6, p, code, blockquote, .md-table, li p";
+  "h1, h2, h3, h4, h5, h6, p, code, blockquote, .md-table, li, li > *";
 const DELIMITER = "=";
 const EXPIRE_AFTER_DAYS = 7;
 const EXPIRE_AFTER_SECONDS = EXPIRE_AFTER_DAYS * 24 * 60 * 60;

--- a/spec/system/placeholder_spec.rb
+++ b/spec/system/placeholder_spec.rb
@@ -68,5 +68,27 @@ RSpec.describe "Placeholder", system: true do
 
       expect(page).to have_link(href: "https://example.com/bar")
     end
+
+    context "when placeholder is used in a[href] of list item" do
+      fab!(:post) { Fabricate(:post, raw: <<~MD) }
+          [wrap=placeholder key=\"TEST1\"][/wrap]
+          - test
+            - [Some link](https://example.com/=TEST1=)
+        MD
+
+      it "replaces string in href" do
+        topic_page.visit_topic(post.topic)
+
+        expect(page).to have_link(href: "https://example.com/=TEST1=")
+
+        page.find('.discourse-placeholder-value[data-key="TEST1"]').fill_in(with: "foo")
+
+        expect(page).to have_link(href: "https://example.com/foo")
+
+        page.find('.discourse-placeholder-value[data-key="TEST1"]').fill_in(with: "bar")
+
+        expect(page).to have_link(href: "https://example.com/bar")
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this fix the following cases wouldn't work:
- nested lists
- a link in a list